### PR TITLE
React Hot Loader support

### DIFF
--- a/lib/autoBind.js
+++ b/lib/autoBind.js
@@ -68,6 +68,9 @@ function boundMethod(objPrototype, method, descriptor) {
         writable: true
       });
       return boundFn;
+    },
+    set: function set(newFn) {
+      fn = newFn;
     }
   };
 }


### PR DESCRIPTION
Adds a setter. When Hot reloading the component, that way, RHL updates the method, and it's not necessary to reload the page.